### PR TITLE
support JSON::XS 2.X

### DIFF
--- a/lib/Web/ChromeLogger.pm
+++ b/lib/Web/ChromeLogger.pm
@@ -5,7 +5,7 @@ use warnings;
 
 our $VERSION = "0.03";
 
-use JSON::XS;
+use JSON::XS qw//;
 use MIME::Base64;
 
 sub new {


### PR DESCRIPTION
JSON::XS 2.X exports the 'to_json' method.
It's also implemeted in Web::ChromeLogger.
This PR removes warnings.
