### PR TITLE
Fix encode() method mis-implementation.

### DIFF
--- a/lib/Web/ChromeLogger.pm
+++ b/lib/Web/ChromeLogger.pm
@@ -107,7 +107,7 @@ sub encode {
         },
     );
     my $mime_data = MIME::Base64::encode_base64($json_data);
-    $mime_data =~ s/\n/''/g;
+    $mime_data =~ s/\n//g;
 
     return $mime_data;
 }


### PR DESCRIPTION
The ChromeLogger tech spec:

```
https://craig.is/writing/chrome-logger/techspecs
```

... specified the base64 encoded result must contain no
newline characters:

```
final_data = utf8_data.encode('base64').replace('\n', '')
```

The newline should be _removed_ instead of being replaced by a pair of
single quotes.
